### PR TITLE
Updated to send device specific row and column sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Collection of scripts to configure Betaflight from your TX over CRSF.
 
 ### Installation
 1.  Upgrade to Betaflight 3.4 (build #792 or later).
-2.  **If you are using a X7 series transmitter, enter `set displayport_crsf_col_adjust = -6` in cli and save before continuing.**
 2.  Copy the `crsfdp.lua` file to the `/SCRIPTS/TELEMETRY/` directory on your Taranis.
 3.  Configure your remote to load the script as a Telemetry screen.  Running the script manually from the SD card is not supported and will not work properly
 4.  Load the telemetry screen and the CMS menus should begin streaming to your remote.
@@ -21,14 +20,5 @@ While it is a technical possibility, it is not likely.  Crossfire is currently t
 The "over-the-air" nature of these protocols are likely to suffer from occasional frame loss, so it is normal that lines may fail to appear on the screen.  If it appears that the CMS didn't load at all or that lines are missing from the display, press the "+" button to refresh the screen. This will instruct the script to request a refresh of the screen you are currently viewing. Given that this capability is in its infancy, bugs are likely to occur so please report them if they are encountered.
 
 #### What if I don't have a X9 or X7?
-Support for other FrSky transmitters is absolutely a possibility, but is not available at this time.  We are eager to provide support for other radios, so if you are a developer wishing to improve the scripts, please feel free to fork and submit a pull request.  Betaflight offers a few configuration parameters that will reduce the width and height of the interactive screen to accomodate smaller displays.
+Support for other FrSky transmitters is absolutely a possibility, but is not available at this time.  We are eager to provide support for other radios, so if you are a developer wishing to improve the scripts, please feel free to fork and submit a pull request.  The `supportedPlatforms` object contains enough flexibility to accomodate any display size with a maximum of 9 rows by 32 columns.
 
-```
-displayport_crsf_col_adjust = 0
-Allowed range: -8 - 0
-
-displayport_crsf_row_adjust = 0
-Allowed range: -3 - 0
-```
-
-Lowering these two parameters into negative ranges will reduce the column (characters per row) and row counts. This will assist in making the screens fit better on smaller remotes.


### PR DESCRIPTION
Updated the LUA scripts to permit the transmitter to send to the FC the desired screen size in rows and columns rather than requiring users to configure a parameter group via CLI for smaller screens.

Updated CRSF spec for display port.

Works with changes found in [#5921](https://github.com/betaflight/betaflight/pull/5921)